### PR TITLE
fix: prevent duplicate form submission (C1)

### DIFF
--- a/app/Http/Controllers/FormController.php
+++ b/app/Http/Controllers/FormController.php
@@ -547,6 +547,21 @@ class FormController extends Controller
     {
         $request->validate(["semester_id as required"]);
 
+        $duplicate = Form::where("student_id", $request->student_id)
+            ->where("semester_id", $request->semester_id)
+            ->where("active", 1)
+            ->first();
+
+        if ($duplicate) {
+            return response()->json(
+                [
+                    "message" => "duplicate",
+                    "error" => "นักศึกษานี้มีใบสมัครในภาคการศึกษานี้แล้ว",
+                ],
+                409
+            );
+        }
+
         $pathNamecard = null;
         if (
             $request->namecard_file != "" &&

--- a/resources/js/pages/student/cwie-data/add.vue
+++ b/resources/js/pages/student/cwie-data/add.vue
@@ -354,6 +354,10 @@ const onSubmit = () => {
                 name: "student-cwie-data",
               });
             });
+          } else if (response.data.message == "duplicate") {
+            isOverlay.value = false;
+            isDialogConfirmVisible.value = false;
+            alert("ไม่สามารถส่งใบสมัครได้: มีใบสมัครในภาคการศึกษานี้แล้ว");
           } else {
             isOverlay.value = false;
             isDialogConfirmVisible.value = false;
@@ -362,7 +366,7 @@ const onSubmit = () => {
         })
         .catch((error) => {
           console.error(error);
-          //   isOverlay.value = false;
+          isOverlay.value = false;
         });
     } else {
       isOverlay.value = false;
@@ -776,7 +780,7 @@ const format = (date) => {
           >
             Cancel
           </VBtn>
-          <VBtn @click="onSubmit()" color="error"> ส่งข้อมูล </VBtn>
+          <VBtn @click="onSubmit()" color="error" :disabled="isOverlay" :loading="isOverlay"> ส่งข้อมูล </VBtn>
         </VCardText>
       </VCard>
     </VDialog>


### PR DESCRIPTION
## Summary
- Disable submit button with `:disabled` and `:loading` while request is in progress to prevent double-click
- Fix commented-out `isOverlay.value = false` in catch block so overlay resets on error
- Add backend duplicate check: returns `409` if `student_id + semester_id + active=1` already exists before creating a new form record

## Test plan
- [ ] Submit form once — should work normally
- [ ] Double-click submit button rapidly — second click should be blocked (button disabled)
- [ ] Simulate network error — overlay should reset and allow resubmission
- [ ] Submit form for same student + semester twice — second submission should show error message

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)