### PR TITLE
fix: prevent form submission with null student_id (C3)

### DIFF
--- a/app/Http/Controllers/FormController.php
+++ b/app/Http/Controllers/FormController.php
@@ -547,6 +547,13 @@ class FormController extends Controller
     {
         $request->validate(["semester_id as required"]);
 
+        if (!$request->student_id) {
+            return response()->json(
+                ["message" => "error", "error" => "student_id is required"],
+                422
+            );
+        }
+
         $duplicate = Form::where("student_id", $request->student_id)
             ->where("semester_id", $request->semester_id)
             ->where("active", 1)
@@ -683,8 +690,10 @@ class FormController extends Controller
         $item->save();
 
         $student = Student::where("id", $item->student_id)->first();
-        $student->status_id = $item->status_id;
-        $student->save();
+        if ($student) {
+            $student->status_id = $item->status_id;
+            $student->save();
+        }
 
         // $student = Student::where("id", $item->student_id)->first();
         // $student->status_id = $item->status_id;

--- a/resources/js/pages/student/cwie-data/add.vue
+++ b/resources/js/pages/student/cwie-data/add.vue
@@ -212,6 +212,10 @@ const fetchStudent = () => {
     .then((response) => {
       if (response.data.message == "success") {
         const { data } = response.data;
+        if (!data || data.length === 0) {
+          console.error("ไม่พบข้อมูลนักศึกษาในระบบ");
+          return;
+        }
         item.value.student_id = data[0].id;
 
         if (
@@ -780,7 +784,7 @@ const format = (date) => {
           >
             Cancel
           </VBtn>
-          <VBtn @click="onSubmit()" color="error" :disabled="isOverlay" :loading="isOverlay"> ส่งข้อมูล </VBtn>
+          <VBtn @click="onSubmit()" color="error" :disabled="isOverlay || !item.student_id" :loading="isOverlay"> ส่งข้อมูล </VBtn>
         </VCardText>
       </VCard>
     </VDialog>


### PR DESCRIPTION
## Summary
- Guard against empty `fetchStudent()` response before accessing `data[0].id` to avoid TypeError
- Disable submit button when `student_id` is not yet loaded (`!item.student_id`)
- Return 422 early in backend if `student_id` is missing/null
- Add null guard for `$student` before updating `student.status_id`

## Root Cause
Students whose `student_code` in the DB didn't match the derived username (via `.slice(1, ...)`) caused `fetchStudent()` to return empty data. Accessing `data[0].id` threw a TypeError, leaving `item.value.student_id` as null. The form was submitted without a valid `student_id`, causing a PHP TypeError on `$student->status_id` (null pointer), resulting in a 500 error and status remaining as draft.

## Test plan
- [ ] Student with matching student_code — submit works normally, status updates to submitted
- [ ] Simulate fetchStudent() returning empty — submit button should remain disabled
- [ ] Submit without student_id via API directly — should receive 422 response

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)