### PR TITLE
fix: save travel_expense from request instead of province override (C4)

### DIFF
--- a/app/Http/Controllers/VisitController.php
+++ b/app/Http/Controllers/VisitController.php
@@ -602,10 +602,9 @@ class VisitController extends Controller
         $item->visit_expense = $request->has("visit_expense")
             ? $request->visit_expense
             : $item->visit_expense;
-        $item->travel_expense = $pv != null ? $pv->travel_expense : null;
-        // $item->travel_expense = $request->has("travel_expense")
-        //     ? $request->travel_expense
-        //     : $item->travel_expense;
+        $item->travel_expense = $request->has("travel_expense")
+            ? $request->travel_expense
+            : $item->travel_expense;
         $item->active = $request->has("active")
             ? $request->active
             : $item->active;


### PR DESCRIPTION
## Summary
- Restore `travel_expense` assignment in `VisitController::edit()` to use `$request->travel_expense` instead of always overriding with the province's default value

## Root Cause
`edit()` was overriding `travel_expense` with `$pv->travel_expense` (province default) on every save — ignoring whatever the user entered. The correct code that reads from the request was commented out. `add()` was unaffected and already saved correctly from the request.

## Test plan
- [ ] Edit a visit and enter a custom `travel_expense` value — value should be saved correctly
- [ ] Generate document after saving — `travel_expense` should no longer be null

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)